### PR TITLE
Add country taxonomy and Länder navigation dropdown

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,100 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repo is
+
+A German-language Hugo static site (`travel.igl-web.de`) documenting a travel blog ("Crocs around the world"). Content is plain Markdown posts; the site is built with Hugo and deployed to GitHub Pages via GitHub Actions.
+
+The theme `hugo-theme-cleanwhite` is pulled in as a **git submodule** under `themes/`. Clones that omit submodules will fail to build — use `git clone --recurse-submodules` or run `git submodule update --init` after cloning.
+
+## Common commands
+
+```bash
+# Local dev server (shows drafts; archetype sets draft: true by default)
+hugo server -D
+
+# Production build (matches the CI build)
+hugo --minify                 # outputs to ./public
+
+# Create a new blog post from archetypes/default.md
+hugo new post/<slug>.md
+
+# Pull/refresh the theme submodule
+git submodule update --init --recursive
+
+# Regenerate data/albums.json from the iCloud album API
+# (not currently run in CI — see .github/workflows/hugo.yml)
+./scripts/fetchalbums.sh
+```
+
+There are no tests, linters, or package managers — the entire toolchain is Hugo + bash.
+
+## Deployment
+
+`.github/workflows/hugo.yml` deploys on every push to `main` (and runs on PRs):
+
+1. Checks out with submodules (required for the theme).
+2. Installs latest Hugo (non-extended) via `peaceiris/actions-hugo`.
+3. Runs `hugo --minify`.
+4. Publishes `./public` to the `gh-pages` branch via `peaceiris/actions-gh-pages`, with `cname: travel.igl-web.de`.
+
+Don't edit `gh-pages` directly — it is overwritten on every deploy. The commented-out Cloudflare purge step and `./scripts/fetchalbums.sh` call in the workflow are intentionally disabled.
+
+## Architecture
+
+### Content model
+
+- `content/post/*.md` — blog posts, filename-prefixed with an ordinal (`1-…`, `2-…`, … `83-…`, plus a later Brazil series `b01-…`, `b02-…`, `B30-…`). This ordering is **semantic**: Hugo's `PrevInSection`/`NextInSection` navigation in `layouts/_default/single.html` relies on date ordering, but humans sort/read by these numbers. Keep them monotonic when adding posts.
+- `content/unsere-route.md` — standalone page linked from the nav menu (see `params.addtional_menus` in `config.toml`).
+- `archetypes/default.md` — front-matter template for `hugo new`; sets `draft: true`.
+
+Typical post front matter (see `content/post/1-aufbruch-in-eine-unbekannte-welt.md`):
+
+```yaml
+title: "#1 - …"
+date: 2022-09-15
+author: Kerstin
+categories: ["Deutschland", "Peru", "Lima"]
+featured: 1
+album: B0OGrq0zwH4gVC      # iCloud shared album ID — drives the gallery
+aliases:                    # legacy WP URL compatibility — preserve when migrating posts
+   - "/2022/09/15/…/"
+```
+
+### Photo galleries (runtime fetch)
+
+Posts embed an iCloud shared-album gallery by declaring `album: <id>` in front matter. The mechanism is in `layouts/partials/image-gallery.html`:
+
+- On page load, client-side JS `fetch()`s `{{ .Site.Params.icloud_api }}/album/{{ album }}` and renders each image into a PhotoSwipe gallery.
+- `icloud_api` is configured in `config.toml` (default: `https://icloud-api.evolution-web.de`; a localhost value is commented out for local API dev).
+- `scripts/fetchalbums.sh` exists to *pre-download* album JSON (into `data/albums.json`) and thumbnails/full images (into `static/img/{thumbs,full}/`, both gitignored). It is currently not invoked by CI, so the site depends on the live API at page-load time.
+
+When touching gallery code, remember both the fetch-at-runtime path (`image-gallery.html`) and the offline-cache path (`fetchalbums.sh`) exist and are meant to be interchangeable.
+
+### Layout overrides
+
+The site uses the `hugo-theme-cleanwhite` theme but **overrides** specific templates at the project root (Hugo's lookup order puts `./layouts/` ahead of `./themes/*/layouts/`):
+
+- `layouts/_default/baseof.html` — adds the "Wir sind gerade hier" location banner, reading `data/location.yaml` (`name` + `url`). Update this file to change the displayed current location.
+- `layouts/_default/single.html` — post template; formats dates using German weekday/month lookups in `data/days_german.toml` and `data/months_german.toml`, and injects the image gallery partial before post content.
+- `layouts/partials/*.html` — overrides for `head`, `nav`, `footer`, `comments`, `image-gallery`, `post_list`, `header`.
+
+Before editing a partial, check whether the override exists locally; if not, copy from `themes/hugo-theme-cleanwhite/layouts/...` into `./layouts/...` rather than editing inside the submodule.
+
+### Comments
+
+Uses [giscus](https://giscus.app) (GitHub Discussions) — config is under `[params.giscus]` in `config.toml`, wired into posts via the theme's comments partial (overridden in `layouts/partials/comments.html`). `disqus_site` and `twikoo_env_id` are present but empty.
+
+### Site-wide data files
+
+- `data/location.yaml` — current location banner (name + Google Maps URL).
+- `data/days_german.toml`, `data/months_german.toml` — German date name lookups used by `single.html`.
+- `data/albums.json` — optional, generated by `fetchalbums.sh`; not required for the runtime-fetch gallery path.
+
+## Conventions
+
+- Site language is German (`languageCode = 'de-de'`); post titles, UI strings, and date formatting are German. Preserve this when adding content or UI text.
+- Preserve legacy WordPress URLs via the `aliases` front-matter list when migrating or renaming posts.
+- Image paths `static/img/thumbs/*.jpg` and `static/img/full/*.jpg` are gitignored — don't commit generated thumbnails.
+- `public/` is gitignored; never commit the build output.

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -2,5 +2,6 @@
 title: "{{ replace .Name "-" " " | title }}"
 date: {{ .Date }}
 draft: true
+country: ""
 ---
 

--- a/config.toml
+++ b/config.toml
@@ -6,6 +6,11 @@ theme = "hugo-theme-cleanwhite"
 
 ### theme config g
 
+[taxonomies]
+  category = "categories"
+  tag = "tags"
+  country = "countries"
+
 [outputs]
 home = ["HTML", "RSS"]
 

--- a/content/post/1-aufbruch-in-eine-unbekannte-welt.md
+++ b/content/post/1-aufbruch-in-eine-unbekannte-welt.md
@@ -3,6 +3,7 @@ title: "#1 - Aufbruch in eine unbekannte Welt"
 date: 2022-09-15
 author: Kerstin
 categories: ["Deutschland", "Peru", "Lima"]
+country: "Deutschland"
 featured: 1
 album: B0OGrq0zwH4gVC
 # This is for the old WP links to still work

--- a/content/post/10-this-is-peru.md
+++ b/content/post/10-this-is-peru.md
@@ -3,6 +3,7 @@ title: "#10 This is Peru"
 date: 2022-10-24
 author: Kerstin
 categories: ["Peru"]
+country: "Peru"
 featured: 18
 album: B19GWZuqDHB5CMV
 ---

--- a/content/post/11-wie-weit-nach-brasilien.md
+++ b/content/post/11-wie-weit-nach-brasilien.md
@@ -3,6 +3,7 @@ title: "#11 Wie lange laufen wir nach Brasilien?"
 date: 2022-10-27
 author: Kerstin
 categories: ["Kolumbien"]
+country: "Kolumbien"
 featured: 3
 album: B19GY8gBYHVR4El
 draft: false

--- a/content/post/12-zurueck-auf-der-nordhalbkugel-2.md
+++ b/content/post/12-zurueck-auf-der-nordhalbkugel-2.md
@@ -3,6 +3,7 @@ title: "#12 Zurück auf der Nordhalbkugel"
 date: 2022-10-29
 author: Kerstin
 categories: ["Kolumbien", "Bogotá"]
+country: "Kolumbien"
 featured: 5
 album: B195nhQSTIzUPRu
 draft: false

--- a/content/post/13-zum-glueck-bewoelkt.md
+++ b/content/post/13-zum-glueck-bewoelkt.md
@@ -3,6 +3,7 @@ title: "#13 Zum Glück bewölkt"
 date: 2022-10-31
 author: Kerstin
 categories: ["Kolumbien", "Tatacoa"]
+country: "Kolumbien"
 featured: 8
 album: B195Uzl7VFG3Z6P
 draft: false

--- a/content/post/14-salsa.md
+++ b/content/post/14-salsa.md
@@ -3,6 +3,7 @@ title: "#14 Salsa"
 date: 2022-11-06
 author: Kerstin
 categories: ["Kolumbien", "Cali"]
+country: "Kolumbien"
 featured: 5
 album: B19Grq0zwIO1oBJ
 draft: false

--- a/content/post/15-coffee-everywhere.md
+++ b/content/post/15-coffee-everywhere.md
@@ -3,6 +3,7 @@ title: "#15 Coffee everywhere"
 date: 2022-11-08
 author: Kerstin
 categories: ["Kolumbien", "Armenia", "Salento"]
+country: "Kolumbien"
 featured: 14
 album: B195n8hH4Izqg2T
 draft: false

--- a/content/post/16-eternal-spring.md
+++ b/content/post/16-eternal-spring.md
@@ -3,6 +3,7 @@ title: "#16 Eternal Spring"
 date: 2022-11-16
 author: Kerstin, Sven
 categories: ["Kolumbien", "Medellin"]
+country: "Kolumbien"
 featured: 5
 album: B19GI9HKKIF7sjw
 draft: false

--- a/content/post/17-back-to-coffee.md
+++ b/content/post/17-back-to-coffee.md
@@ -3,6 +3,7 @@ title: "#17 Back to Coffee"
 date: 2022-11-20
 author: Kerstin
 categories: ["Kolumbien", "Jardin"]
+country: "Kolumbien"
 featured: 13
 album: B195yeZFh8AYWp7
 draft: false

--- a/content/post/18-schoene-gruesse-vom-meer.md
+++ b/content/post/18-schoene-gruesse-vom-meer.md
@@ -3,6 +3,7 @@ title: "#18 Schöne Grüße vom Meer"
 date: 2022-11-21
 author: Kerstin
 categories: ["Kolumbien", "Palomino", "Santa Marta"]
+country: "Kolumbien"
 featured: 2
 album: B1959UlCq8tuOcD
 draft: false

--- a/content/post/19-karibikfeeling.md
+++ b/content/post/19-karibikfeeling.md
@@ -3,6 +3,7 @@ title: "#19 Karibikfeeling"
 date: 2022-11-24
 author: Sven
 categories: ["Kolumbien", "Cartagena"]
+country: "Kolumbien"
 featured: 3
 album: B19J0DiRHIegBVz
 #

--- a/content/post/2-wundervolle-anden.md
+++ b/content/post/2-wundervolle-anden.md
@@ -3,6 +3,7 @@ title: "#2 Wundervolle Anden"
 date: 2022-09-20
 author: Kerstin
 categories: ["Peru", "Huaraz"]
+country: "Peru"
 featured: 7
 album: B0O5n8hH4GTacJw
 # This is for the old WP links to still work

--- a/content/post/20-happy-bubbles.md
+++ b/content/post/20-happy-bubbles.md
@@ -3,6 +3,7 @@ title: "#20 Happy Bubbles"
 date: 2022-11-28
 author: Kerstin
 categories: ["Kolumbien", "San Andres"]
+country: "Kolumbien"
 featured: 25
 album: B195ON9t38Ken8S
 draft: false

--- a/content/post/21-how-is-colombia.md
+++ b/content/post/21-how-is-colombia.md
@@ -3,6 +3,7 @@ title: "#21 How is Colombia"
 date: 2022-12-03
 author: Kerstin
 categories: ["Kolumbien"]
+country: "Kolumbien"
 featured: 7
 album: B19GqkRUiIFlzpQ
 draft: false

--- a/content/post/22-alles-in-butter.md
+++ b/content/post/22-alles-in-butter.md
@@ -3,6 +3,7 @@ title: "#22 Alles in Butter"
 date: 2022-12-04
 author: Kerstin
 categories: ["Mexiko", "Cancun"]
+country: "Mexiko"
 featured: 2
 album: B19GfnH8t8DDLJj
 draft: false

--- a/content/post/23-noch-ein-letztes-mal-karibik-2.md
+++ b/content/post/23-noch-ein-letztes-mal-karibik-2.md
@@ -3,6 +3,7 @@ title: "#23 Noch ein letztes Mal Karibik"
 date: 2022-12-07
 author: Kerstin
 categories: ["Mexiko", "Tulum"]
+country: "Mexiko"
 featured: 9
 album: B1953qWtH8kQwKf
 draft: false

--- a/content/post/24-ruins.md
+++ b/content/post/24-ruins.md
@@ -3,6 +3,7 @@ title: "#24 Ruinen"
 date: 2022-12-10
 author: Kerstin
 categories: ["Mexiko", "Palenque"]
+country: "Mexiko"
 featured: 11
 album: B19GgZLKuIX2kjV
 draft: false

--- a/content/post/25-wie-viele-quesadillas-sind-das-2.md
+++ b/content/post/25-wie-viele-quesadillas-sind-das-2.md
@@ -3,6 +3,7 @@ title: "#25 Wie viele Quesadillas sind das?"
 date: 2022-12-13
 author: Kerstin
 categories: ["Mexiko", "Mexiko-Stadt"]
+country: "Mexiko"
 featured: 27
 album: B19GtnIOR8owUR5
 draft: false

--- a/content/post/26-where-to-go-next.md
+++ b/content/post/26-where-to-go-next.md
@@ -3,6 +3,7 @@ title: "#26 Where to go next?"
 date: 2022-12-14
 author: Kerstin
 categories: ["Mexiko", "Guadalajara"]
+country: "Mexiko"
 featured: 11
 album: B19JEsNWnITpUUL
 draft: false

--- a/content/post/27-border-crossing.md
+++ b/content/post/27-border-crossing.md
@@ -3,6 +3,7 @@ title: "#27 Border crossing"
 date: 2022-12-19
 author: Kerstin
 categories: ["Mexiko", "Tijuana"]
+country: "Mexiko"
 featured: 2
 album: B19Gf693Z8T9OmK
 draft: false

--- a/content/post/28-600-meilen.md
+++ b/content/post/28-600-meilen.md
@@ -3,6 +3,7 @@ title: "#28 600 Meilen"
 date: 2022-12-22
 author: Kerstin
 categories: ["USA"]
+country: "USA"
 featured: 58
 album: B1955Z2WM8iy4Ke
 draft: false

--- a/content/post/29-1200-extra-miles.md
+++ b/content/post/29-1200-extra-miles.md
@@ -3,6 +3,7 @@ title: "#29 1200 Extra-Miles"
 date: 2022-12-23
 author: Kerstin
 categories: ["USA"]
+country: "USA"
 featured: 3
 album: B0OGqkRUiIifdl
 draft: false

--- a/content/post/3-ein-wenig-kultur.md
+++ b/content/post/3-ein-wenig-kultur.md
@@ -3,6 +3,7 @@ title: "#3 Ein wenig Kultur"
 date: 2022-09-23
 author: Kerstin
 categories: ["Peru", "Trujillo"]
+country: "Peru"
 featured: 2
 album: B0OGI9HKKFMYH1
 # This is for the old WP links to still work

--- a/content/post/30-frosty.md
+++ b/content/post/30-frosty.md
@@ -3,6 +3,7 @@ title: "#30 Frosty"
 date: 2022-12-26
 author: Kerstin
 categories: ["USA"]
+country: "USA"
 featured: 17
 album: B0VJtdOXmGElR47
 draft: false

--- a/content/post/31-weihnachtsstimmung.md
+++ b/content/post/31-weihnachtsstimmung.md
@@ -3,6 +3,7 @@ title: "#31 Weihnachtsstimmung"
 date: 2022-12-27
 author: Kerstin
 categories: ["Kanada"]
+country: "Kanada"
 featured: 4
 album: B195fk75v8Nl280
 draft: false

--- a/content/post/32-verrueckte-weihnachten.md
+++ b/content/post/32-verrueckte-weihnachten.md
@@ -3,6 +3,7 @@ title: "#32 Verrückte Weihnachten"
 date: 2022-12-29
 author: Kerstin
 categories: ["Australien", "Newcastle"]
+country: "Australien"
 featured: 2
 album: B195idkMw8utWd7
 draft: false

--- a/content/post/33-drei-vans.md
+++ b/content/post/33-drei-vans.md
@@ -3,6 +3,7 @@ title: "#33 Drei Vans"
 date: 2022-12-30
 author: Kerstin
 categories: ["Australien", "Sydney"]
+country: "Australien"
 featured: 3
 album: B195GH8Mq87StPf
 draft: false

--- a/content/post/34-ein-perfekter-start.md
+++ b/content/post/34-ein-perfekter-start.md
@@ -3,6 +3,7 @@ title: "#34 Ein perfekter Start"
 date: 2023-01-01
 author: Kerstin
 categories: ["Australien", "Wollongong"]
+country: "Australien"
 featured: 3
 album: B19GRMtznIpXeGi
 draft: false

--- a/content/post/35-roos-and-wombats.md
+++ b/content/post/35-roos-and-wombats.md
@@ -3,6 +3,7 @@ title: "#35 Roos & Wombats"
 date: 2023-01-09
 author: Kerstin
 categories: ["Australien", "Jervis Bay"]
+country: "Australien"
 featured: 1
 album: B0OGtnIORJ0HXsf
 draft: false

--- a/content/post/36-von-den-blauen-bergen.md
+++ b/content/post/36-von-den-blauen-bergen.md
@@ -3,6 +3,7 @@ title: "#36 Von den blauen Bergen"
 date: 2023-01-11
 author: Sven
 categories: ["Australien", "Katoomba"]
+country: "Australien"
 featured: 2
 album: B0O5VaUrzGjDHCR
 draft: false

--- a/content/post/37-koalas-zum-schluss.md
+++ b/content/post/37-koalas-zum-schluss.md
@@ -3,6 +3,7 @@ title: "#37 Koalas zum Schluss"
 date: 2023-01-14
 author: Kerstin
 categories: ["Australien", "Newcastle"]
+country: "Australien"
 featured: 4
 album: B0OJEsNWnGfTJq3
 draft: false

--- a/content/post/38-geckogesang.md
+++ b/content/post/38-geckogesang.md
@@ -3,6 +3,7 @@ title: "#38 Geckogesang"
 date: 2023-01-22
 author: Kerstin
 categories: ["Indonesien", "Bali", "Bukit", "Kuta"]
+country: "Indonesien"
 featured: 9
 album: B19GQOeMmIY8S6E
 draft: false

--- a/content/post/39-maybe-tomorrow.md
+++ b/content/post/39-maybe-tomorrow.md
@@ -3,6 +3,7 @@ title: "#39 Maybe tomorrow"
 date: 2023-01-23
 author: Kerstin
 categories: ["Indonesien", "Bali", "Ubud"]
+country: "Indonesien"
 featured: 4
 album: B195aVbMK8aUpX0
 draft: false

--- a/content/post/4-zehen-im-pazifik.md
+++ b/content/post/4-zehen-im-pazifik.md
@@ -3,6 +3,7 @@ title: "#4 Zehen im Pazifik"
 date: 2022-09-26
 author: Kerstin
 categories: ["Peru", "Huanchaco"]
+country: "Peru"
 featured: 2
 album: B0O5yeZFhGkFrog
 # This is for the old WP links to still work

--- a/content/post/40-kibbel-ruff-kibbel-runner.md
+++ b/content/post/40-kibbel-ruff-kibbel-runner.md
@@ -3,6 +3,7 @@ title: "#40 Kibbel ruff, Kibbel runner"
 date: 2023-01-24
 author: Kerstin
 categories: ["Indonesien", "Bali", "Munduk", "Sanur"]
+country: "Indonesien"
 featured: 15
 album: B195ejO17IwnFXa
 draft: false

--- a/content/post/41-bright-side-of-bali.md
+++ b/content/post/41-bright-side-of-bali.md
@@ -3,6 +3,7 @@ title: "#41 Bright side of Bali"
 date: 2023-01-30
 author: Kerstin
 categories: ["Indonesien", "Bali", "Nusa Penida"]
+country: "Indonesien"
 featured: 20
 album: B19GdIshaIfncib
 draft: false

--- a/content/post/42-volcanos.md
+++ b/content/post/42-volcanos.md
@@ -3,6 +3,7 @@ title: "#42 Volcanos"
 date: 2023-02-04
 author: Kerstin
 categories: ["Indonesien", "Java", "Jawa-Timur"]
+country: "Indonesien"
 featured: 23
 album: B195M7GFP8Mapb0
 draft: false

--- a/content/post/43-sechzig-tage.md
+++ b/content/post/43-sechzig-tage.md
@@ -3,6 +3,7 @@ title: "#43 60 days"
 date: 2023-02-12
 author: Kerstin
 categories: ["Indonesien", "Java", "Yogyakarta"]
+country: "Indonesien"
 featured: 14
 album: B1952plgj8pXd86
 draft: false

--- a/content/post/44-es-brodelt.md
+++ b/content/post/44-es-brodelt.md
@@ -3,6 +3,7 @@ title: "#44 Es brodelt"
 date: 2023-02-19
 author: Kerstin
 categories: ["Indonesien", "Java", "Jawa-Tengah"]
+country: "Indonesien"
 featured: 30
 album: B195NI45M80qGxL
 draft: false

--- a/content/post/45-sightseeing.md
+++ b/content/post/45-sightseeing.md
@@ -3,6 +3,7 @@ title: "#45 Sightseeing"
 date: 2023-02-23
 author: Kerstin
 categories: ["Indonesien", "Java", "Jawa-Barat"]
+country: "Indonesien"
 featured: 25
 album: B195CmvAS8wx13N
 draft: false

--- a/content/post/46-1000-inseln.md
+++ b/content/post/46-1000-inseln.md
@@ -3,6 +3,7 @@ title: "#46 1000 Inseln"
 date: 2023-02-26
 author: Kerstin
 categories: ["Indonesien", "Java", "Jawa-Barat"]
+country: "Indonesien"
 featured: 5
 album: B0OGf693ZJHXmXS
 draft: false

--- a/content/post/47-mister.md
+++ b/content/post/47-mister.md
@@ -3,6 +3,7 @@ title: "#47 Mister"
 date: 2023-03-01
 author: Kerstin
 categories: ["Indonesien", "Sumatra", "South-Sumatra"]
+country: "Indonesien"
 featured: 21
 album: B19GdPblXI04Sbk
 draft: false

--- a/content/post/48-selamat-nikah.md
+++ b/content/post/48-selamat-nikah.md
@@ -3,6 +3,7 @@ title: "#48 Selamat Nikah"
 date: 2023-03-10
 author: Kerstin
 categories: ["Indonesien", "Sumatra", "West-Sumatra"]
+country: "Indonesien"
 featured: 42
 album: B19JRveFpI7WJtS
 draft: false

--- a/content/post/49-ueber-neun-bruecken.md
+++ b/content/post/49-ueber-neun-bruecken.md
@@ -3,6 +3,7 @@ title: "#49 Über 9 Brücken"
 date: 2023-03-15
 author: Kerstin
 categories: ["Indonesien", "Sumatra", "North-Sumatra"]
+country: "Indonesien"
 featured: 18
 album: B195aDWbr8aZXAi
 draft: false

--- a/content/post/5-inkakultur.md
+++ b/content/post/5-inkakultur.md
@@ -3,6 +3,7 @@ title: "#5 Inkakultur"
 date: 2022-09-30
 author: Kerstin
 categories: ["Peru", "Cajamarca"]
+country: "Peru"
 featured: 5
 album: B0O59UlCqGY1U67
 # This is for the old WP links to still work

--- a/content/post/50-maenner-mit-vogel.md
+++ b/content/post/50-maenner-mit-vogel.md
@@ -3,6 +3,7 @@ title: "#50 Männer mit Vogel"
 date: 2023-03-20
 author: Kerstin
 categories: ["Indonesien"]
+country: "Indonesien"
 featured: 31
 album: B19GJDfWG8l4xYb
 draft: false

--- a/content/post/51-happy-streetfood.md
+++ b/content/post/51-happy-streetfood.md
@@ -3,6 +3,7 @@ title: "#51 Happy Streetfood"
 date: 2023-03-21
 author: Kerstin
 categories: ["Malaysia" , "Penang"]
+country: "Malaysia"
 featured: 66
 album: B19GIcgc2IF1xOe
 draft: false

--- a/content/post/52-fastenzeit.md
+++ b/content/post/52-fastenzeit.md
@@ -3,6 +3,7 @@ title: "#52 Fastenzeit"
 date: 2023-03-27
 author: Kerstin
 categories: ["Malaysia" , "Terengganu" , "Mersing"]
+country: "Malaysia"
 featured: 1
 album: B19G0ehgL83hCO9
 draft: false

--- a/content/post/53-schildkroeten.md
+++ b/content/post/53-schildkroeten.md
@@ -3,6 +3,7 @@ title: "#53 Schildkröten"
 date: 2023-03-28
 author: Kerstin
 categories: ["Malaysia" , "Tioman"]
+country: "Malaysia"
 featured: 12
 album: B19Ju8EH6IlzF3J
 draft: false

--- a/content/post/54-freudentraenen.md
+++ b/content/post/54-freudentraenen.md
@@ -3,6 +3,7 @@ title: "#54 Freudentränen"
 date: 2023-04-02
 author: Kerstin
 categories: ["Malaysia" , "KL" , "Melaka"]
+country: "Malaysia"
 featured: 4
 album: B195BydzF8BBvn8
 draft: false

--- a/content/post/55-30x2+31.md
+++ b/content/post/55-30x2+31.md
@@ -3,6 +3,7 @@ title: "#55 30 x 2 + 31"
 date: 2023-04-07
 author: Kerstin
 categories: ["Malaysia" , "Cameron Highlands"]
+country: "Malaysia"
 featured: 6
 album: B19G4VTwGHLBeGf
 draft: false

--- a/content/post/56-batcave.md
+++ b/content/post/56-batcave.md
@@ -3,6 +3,7 @@ title: "#56 Batcave"
 date: 2023-04-10
 author: Sven
 categories: ["Malaysia" , "Taman Negara" , "Kuala Tahan"]
+country: "Malaysia"
 featured: 22
 album: B19GrhkPxIOCoAo
 draft: false

--- a/content/post/57-schwarze-finne.md
+++ b/content/post/57-schwarze-finne.md
@@ -3,6 +3,7 @@ title: "#57 Schwarze Finne"
 date: 2023-04-14
 author: Sven
 categories: ["Malaysia" , "Perhentian" , "Long Beach", "Tauchen"]
+country: "Malaysia"
 featured: 4
 album: B195fEtEv8dVsIm
 draft: false

--- a/content/post/58-hari-raya.md
+++ b/content/post/58-hari-raya.md
@@ -3,6 +3,7 @@ title: "#58 Hari Raya"
 date: 2023-04-23
 author: Kerstin
 categories: ["Malaysia" , "Penang" , "Langkawi"]
+country: "Malaysia"
 featured: 13
 album: B19GdFryYIflsu5
 draft: false

--- a/content/post/59-malaysia.md
+++ b/content/post/59-malaysia.md
@@ -3,6 +3,7 @@ title: "#59 Malaysia"
 date: 2023-05-05
 author: Kerstin
 categories: ["Malaysia"]
+country: "Malaysia"
 featured: 9
 album: B19GVfZ2vHB7z0c
 draft: false

--- a/content/post/6-we-entered-the-amazonas.md
+++ b/content/post/6-we-entered-the-amazonas.md
@@ -3,6 +3,7 @@ title: "#6 We entered the Amazonas region"
 date: 2022-10-03
 author: Kerstin
 categories: ["Peru", "Chachapoyas"]
+country: "Peru"
 featured: 4
 album: B0OJ0DiRHGu5rnb
 # This is for the old WP links to still work

--- a/content/post/60-inselfieber.md
+++ b/content/post/60-inselfieber.md
@@ -3,6 +3,7 @@ title: "#60 Inselfieber"
 date: 2023-05-07
 author: Kerstin
 categories: ["Thailand" , "Lipe" , "Adang" , "Lanta" , "Phi Phi"]
+country: "Thailand"
 featured: 11
 album: B19GhtLJ3IXJm9n
 draft: false

--- a/content/post/61-koh-koh-koh.md
+++ b/content/post/61-koh-koh-koh.md
@@ -3,6 +3,7 @@ title: "#61 Koh Koh Koh"
 date: 2023-05-21
 author: Kerstin
 categories: ["Thailand" , "Ao Nang" , "Samui" , "Pha-ngan" , "Tao"]
+country: "Thailand"
 featured: 52
 album: B19JqstnBI9pf1P
 draft: false

--- a/content/post/62-flashbacks.md
+++ b/content/post/62-flashbacks.md
@@ -3,6 +3,7 @@ title: "#62 Flashbacks"
 date: 2023-05-22
 author: Kerstin
 categories: ["Thailand" , "Bangkok"]
+country: "Thailand"
 featured: 1
 album: B19Jr1PPdIc01He
 draft: false

--- a/content/post/63-erste-eindruecke.md
+++ b/content/post/63-erste-eindruecke.md
@@ -3,6 +3,7 @@ title: "#63 Erste Eindrücke"
 date: 2023-05-26
 author: Kerstin
 categories: ["Kambodscha" , "Battambang"]
+country: "Kambodscha"
 featured: 1
 album: B19J8GySPI2825T
 draft: false

--- a/content/post/64-angkor.md
+++ b/content/post/64-angkor.md
@@ -3,6 +3,7 @@ title: "#64 Angkor"
 date: 2023-05-28
 author: Kerstin, Sven
 categories: ["Kambodscha" , "Siem Reap"]
+country: "Kambodscha"
 featured: 36
 album: B19GzFCC1IWFU1s
 draft: false

--- a/content/post/65-something.md
+++ b/content/post/65-something.md
@@ -3,6 +3,7 @@ title: "#65 Something"
 date: 2023-06-01
 author: Kerstin
 categories: ["Kambodscha" , "Phnom Penh" , "Kratie"]
+country: "Kambodscha"
 featured: 8
 album: B19GPCdxkIqhzOS
 draft: false

--- a/content/post/66-gestrandet.md
+++ b/content/post/66-gestrandet.md
@@ -3,6 +3,7 @@ title: "#66 Gestrandet"
 date: 2023-06-05
 author: Kerstin
 categories: ["Kambodscha" , "Sihanoukville" , "Koh Rong Sanloem"]
+country: "Kambodscha"
 featured: 6
 album: B19GWBC59HB5nyy
 draft: false

--- a/content/post/67-wo-der-pfeffer-waechst.md
+++ b/content/post/67-wo-der-pfeffer-waechst.md
@@ -3,6 +3,7 @@ title: "#67 Wo der Pfeffer wächst"
 date: 2023-06-09
 author: Kerstin
 categories: ["Kambodscha" , "Kampot" , "Kep"]
+country: "Kambodscha"
 featured: 9
 album: B19JsHvHoInAnhU
 draft: false

--- a/content/post/68-mekong.md
+++ b/content/post/68-mekong.md
@@ -3,6 +3,7 @@ title: "#68 Mekong"
 date: 2023-06-11
 author: Kerstin
 categories: ["Vietnam" , "Can Tho"]
+country: "Vietnam"
 featured: 9
 album: B19J058xyIeKh89
 draft: false

--- a/content/post/69-fuer-kleine-leute.md
+++ b/content/post/69-fuer-kleine-leute.md
@@ -3,6 +3,7 @@ title: "#69 Für kleine Leute"
 date: 2023-06-14
 author: Kerstin
 categories: ["Vietnam" , "HCMC"]
+country: "Vietnam"
 featured: 14
 album: B19GKQPy6IEL17U
 draft: false

--- a/content/post/7-waermer.md
+++ b/content/post/7-waermer.md
@@ -3,6 +3,7 @@ title: "#7 Wärmer..."
 date: 2022-10-13
 author: Kerstin
 categories: ["Peru", "Tarapoto"]
+country: "Peru"
 featured: 3
 album: B195oqs3qIAea6b
 ---

--- a/content/post/70-coffee-again.md
+++ b/content/post/70-coffee-again.md
@@ -3,6 +3,7 @@ title: "#70 Coffee again"
 date: 2023-06-17
 author: Kerstin
 categories: ["Vietnam" , "Da Lat"]
+country: "Vietnam"
 featured: 13
 album: B19GAfJVYIUJbDM
 draft: false

--- a/content/post/71-keine-runde-sache.md
+++ b/content/post/71-keine-runde-sache.md
@@ -3,6 +3,7 @@ title: "#71 Keine runde Sache"
 date: 2023-06-21
 author: Kerstin
 categories: ["Vietnam" , "Da Nang" , "Hoi An"]
+country: "Vietnam"
 featured: 16
 album: B195kuVsb8x5kqR
 draft: false

--- a/content/post/72-13-koenige.md
+++ b/content/post/72-13-koenige.md
@@ -3,6 +3,7 @@ title: "#72 13 Könige"
 date: 2023-06-24
 author: Kerstin
 categories: ["Vietnam" , "Hue"]
+country: "Vietnam"
 featured: 9
 album: B19GqQrCLIFmKNS
 draft: false

--- a/content/post/73-tiger-und-baeren.md
+++ b/content/post/73-tiger-und-baeren.md
@@ -3,6 +3,7 @@ title: "#73 Tiger und Bären"
 date: 2023-06-27
 author: Kerstin
 categories: ["Vietnam" , "Dong Hoi" , "Phong Nha"]
+country: "Vietnam"
 featured: 11
 album: B195cLqfNIhWx7F
 draft: false

--- a/content/post/74-sprung-ins-meer.md
+++ b/content/post/74-sprung-ins-meer.md
@@ -3,6 +3,7 @@ title: "#74 Sprung ins Meer"
 date: 2023-06-30
 author: Kerstin
 categories: ["Vietnam" , "Ninh Binh" , "Ha Long"]
+country: "Vietnam"
 featured: 14
 album: B19GLLXGLIBeiYP
 draft: false

--- a/content/post/75-ruebber-und-nuebber.md
+++ b/content/post/75-ruebber-und-nuebber.md
@@ -3,6 +3,7 @@ title: "#75 Rübber und Nübber"
 date: 2023-07-06
 author: Kerstin
 categories: ["Vietnam" , "Ha Giang" , "Hanoi"]
+country: "Vietnam"
 featured: 5
 album: B19GDZLe8HkQald
 draft: false

--- a/content/post/76-rollermoshpit.md
+++ b/content/post/76-rollermoshpit.md
@@ -3,6 +3,7 @@ title: "#76 Roller-Moshpit"
 date: 2023-07-09
 author: Kerstin
 categories: ["Vietnam" , "Kambodscha"]
+country: "Vietnam"
 featured: 29
 album: B195p3ich82f8wv
 draft: false

--- a/content/post/77-sushimi.md
+++ b/content/post/77-sushimi.md
@@ -3,6 +3,7 @@ title: "#77 Sashimi"
 date: 2023-07-10
 author: Kerstin
 categories: ["Südkorea" , "Busan"]
+country: "Südkorea"
 featured: 19
 album: B19J5HumnIVPb8t
 draft: false

--- a/content/post/78-zwischen-bergen-und-meer.md
+++ b/content/post/78-zwischen-bergen-und-meer.md
@@ -3,6 +3,7 @@ title: "#78 Zwischen Bergen und Meer"
 date: 2023-07-20
 author: Kerstin
 categories: ["Südkorea"]
+country: "Südkorea"
 featured: 43
 album: B19GsCn7G8n2oYE
 draft: false

--- a/content/post/79-lets-go.md
+++ b/content/post/79-lets-go.md
@@ -3,6 +3,7 @@ title: "#79 Let´s go"
 date: 2023-07-26
 author: Kerstin
 categories: ["Südkorea"]
+country: "Südkorea"
 featured: 7
 album: B19G9Gd2NItwn4S
 draft: false

--- a/content/post/8-a-long-journey.md
+++ b/content/post/8-a-long-journey.md
@@ -3,6 +3,7 @@ title: "#8 A long journey"
 date: 2022-10-15
 author: Kerstin
 categories: ["Peru", "Amazonas"]
+country: "Peru"
 featured: 10
 album: B19532ODW8kbMcC
 ---

--- a/content/post/80-endstation.md
+++ b/content/post/80-endstation.md
@@ -3,6 +3,7 @@ title: "#80 Endstation"
 date: 2023-08-04
 author: Kerstin
 categories: ["Südkorea" , "Seoul"]
+country: "Südkorea"
 featured: 12
 album: B19G1CvrSIEzAlq
 draft: false

--- a/content/post/81-southkorea.md
+++ b/content/post/81-southkorea.md
@@ -3,6 +3,7 @@ title: "#81 Kleiner Kulturschock"
 date: 2023-08-05
 author: Kerstin
 categories: ["Südkorea"]
+country: "Südkorea"
 featured: 9
 album: B19Jq4WnLI9Y8cv
 draft: false

--- a/content/post/82-wiedersehen.md
+++ b/content/post/82-wiedersehen.md
@@ -3,6 +3,7 @@ title: "#82 Wiedersehen"
 date: 2023-08-06
 author: Kerstin
 categories: ["Ende"]
+country: "Deutschland"
 featured: 1
 album: B195ZhN2v8gWPSG
 draft: false

--- a/content/post/83-zahlen-daten-fakten.md
+++ b/content/post/83-zahlen-daten-fakten.md
@@ -3,6 +3,7 @@ title: "#83 Zahlen, Daten, Fakten"
 date: 2023-08-07
 author: Kerstin
 categories: ["Ende"]
+country: "Deutschland"
 featured: 0
 album: B19JPrgBGI1uHld
 draft: false

--- a/content/post/9-welcome-to-the-jungle.md
+++ b/content/post/9-welcome-to-the-jungle.md
@@ -3,6 +3,7 @@ title: "#9 Welcome to the jungle"
 date: 2022-10-21
 author: Kerstin
 categories: ["Peru", "Iquitos"]
+country: "Peru"
 featured: 2
 album: B19G4TcsmHMEHVP
 ---

--- a/content/post/B30-one-caipi-a-day.md
+++ b/content/post/B30-one-caipi-a-day.md
@@ -3,6 +3,7 @@ title: "#B30 - One Caipi a day"
 date: 2024-07-03
 author: Kerstin
 categories: ["Brasilien"]
+country: "Brasilien"
 featured: 
 album: 
 draft: true

--- a/content/post/b01-10-monate-spaeter.md
+++ b/content/post/b01-10-monate-spaeter.md
@@ -3,6 +3,7 @@ title: "#B01 - 10 Monate später"
 date: 2024-06-06
 author: Kerstin
 categories: ["Brasilien" , "Sao Paulo"]
+country: "Brasilien"
 featured: 17
 album: B19JOFSVFIRkBEw
 draft: false

--- a/content/post/b02-wiedersehen-mit-dem-atlantik.md
+++ b/content/post/b02-wiedersehen-mit-dem-atlantik.md
@@ -3,6 +3,7 @@ title: "#B02 - Wiedersehen mit dem Atlantik"
 date: 2024-06-11
 author: Kerstin
 categories: ["Brasilien" , "Costa Verde"]
+country: "Brasilien"
 featured: 2
 album: B19G60dj68TOjjn
 draft: false

--- a/content/post/b03-mehr-meer.md
+++ b/content/post/b03-mehr-meer.md
@@ -3,6 +3,7 @@ title: "#B03 - Mehr Meer"
 date: 2024-06-14
 author: Kerstin
 categories: ["Brasilien" , "Ilha Grande"]
+country: "Brasilien"
 featured: 16
 album: B195FrPQ68R2er2
 draft: false

--- a/content/post/b04-festivals.md
+++ b/content/post/b04-festivals.md
@@ -3,6 +3,7 @@ title: "#B04 - Festivals"
 date: 2024-06-18
 author: Kerstin
 categories: ["Brasilien" , "Diamantina" , "Salvador"]
+country: "Brasilien"
 featured: 7
 album: B19GnbeumHAblKS
 draft: false

--- a/content/post/b05-perigo.md
+++ b/content/post/b05-perigo.md
@@ -3,6 +3,7 @@ title: "#B05 - Perigo"
 date: 2024-06-21
 author: Kerstin
 categories: ["Brasilien" , "Maragogi" , "Recife"]
+country: "Brasilien"
 featured: 15
 album: B19Gtec4X8nCmDH
 draft: false

--- a/content/post/b06-golfinhos.md
+++ b/content/post/b06-golfinhos.md
@@ -3,6 +3,7 @@ title: "#B06 - Golfinhos"
 date: 2024-06-25
 author: Kerstin
 categories: ["Brasilien" , "Pipa"]
+country: "Brasilien"
 featured: 1
 album: B19JOX8tMIRDqLL
 draft: false

--- a/content/post/b07-duenen.md
+++ b/content/post/b07-duenen.md
@@ -3,6 +3,7 @@ title: "#B07 - Sanddünen"
 date: 2024-06-29
 author: Kerstin
 categories: ["Brasilien" , "Fortaleza" , "Jericoacoara"]
+country: "Brasilien"
 featured: 21
 album: B19G7HOIlIJYuMH
 draft: false

--- a/content/post/b08-rio.md
+++ b/content/post/b08-rio.md
@@ -3,6 +3,7 @@ title: "#B08 - Rio"
 date: 2024-07-03
 author: Kerstin
 categories: ["Brasilien" , "Rio de Janeiro"]
+country: "Brasilien"
 featured: 1
 album: B19G3KxPyHkczRC
 draft: false

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -1,0 +1,26 @@
+{{ define "header" }}
+<header class="intro-header" style="background-image: url('{{ .Site.Params.header_image | relURL }}')">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
+                <div class="site-heading">
+                    <h1>{{ .Title }}</h1>
+                    <span class="subheading">{{ len .Pages }} {{ if eq (len .Pages) 1 }}Post{{ else }}Posts{{ end }}</span>
+                </div>
+            </div>
+        </div>
+    </div>
+</header>
+{{ end }}
+
+{{ define "main" }}
+<article>
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1 post-container">
+                {{ partial "post_list.html" . }}
+            </div>
+        </div>
+    </div>
+</article>
+{{ end }}

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -28,6 +28,18 @@
                     <li>
                         <a href="{{ "/" | relLangURL }}">Alle Posts</a>
                     </li>
+                    {{ with .Site.Taxonomies.countries }}
+                    <li class="dropdown">
+                        <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Länder <span class="caret"></span></a>
+                        <ul class="dropdown-menu">
+                            {{ range $name, $taxonomy := . }}
+                            <li>
+                                <a href="{{ (printf "countries/%s/" ($name | urlize)) | relLangURL }}">{{ $name }} <span class="badge">{{ len $taxonomy.Pages }}</span></a>
+                            </li>
+                            {{ end }}
+                        </ul>
+                    </li>
+                    {{ end }}
                     {{ if not .Site.Params.omit_categories }}
                         {{ range $name, $taxonomy := .Site.Taxonomies.categories }}
                         <li>
@@ -35,7 +47,7 @@
                         </li>
                         {{ end }}
                     {{ end }}
-                    
+
 		    {{ range .Site.Params.addtional_menus }}
                         <li><a href="{{.href | relLangURL}}">{{.title}}</a></li>
                     {{ end }}


### PR DESCRIPTION
## Summary

- Adds a new `country` front-matter field (declared as the `countries` Hugo taxonomy) so posts can be filtered by country without overloading the existing free-form `categories` list.
- Backfills `country` on all 92 existing posts by mapping the first `categories` entry → country (wrap-up posts #82/#83 with `categories: ["Ende"]` are mapped to Deutschland since they cover the return home). Result: 14 distinct countries — Indonesien (13), Kolumbien (11), Vietnam (9), Peru (9), Malaysia (9), Brasilien (9), Mexiko (6), Australien (6), Südkorea (5), Kambodscha (5), USA (3), Thailand (3), Deutschland (3), Kanada (1).
- Adds a Bootstrap "Länder" dropdown to the navbar listing each country with its post-count badge, linking to `/countries/<name>/`.
- Adds `layouts/_default/term.html` so country pages render a paginated post list using the existing `post_list.html` partial.
- Updates archetype to include `country: ""` so new posts prompt for the value.
- Also includes the earlier commit adding `CLAUDE.md` from this branch.

## Test plan

- [ ] `hugo server -D` locally — verify the navbar shows a "Länder" dropdown with all 14 countries and correct counts.
- [ ] Click each country in the dropdown and confirm `/countries/<name>/` renders with the expected list of posts.
- [ ] Open an existing post (e.g. `/post/10-this-is-peru/`) and confirm the page still renders (no regressions from the nav change).
- [ ] Verify `hugo new post/test.md` produces a file with `country: ""` in the front matter (then delete).
- [ ] Confirm the CI build in GitHub Actions succeeds and the deployed site has the dropdown working.

https://claude.ai/code/session_01JxRAzzVw6WKmHqSGHBy1JN